### PR TITLE
Address Obsidian automated-review findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
 
@@ -26,14 +28,14 @@ jobs:
       - name: Derive tag
         run: |
           echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "PLUGIN_NAME=cloudflare-kv-sync" >> $GITHUB_ENV
           echo "DIST_DIR=dist" >> $GITHUB_ENV
 
-      - name: Package release zip
-        run: |
-          mkdir "$PLUGIN_NAME"
-          cp $DIST_DIR/* "$PLUGIN_NAME/"
-          zip -r "$PLUGIN_NAME-$TAG.zip" "$PLUGIN_NAME"
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/main.js
+            dist/styles.css
 
       - name: Create release
         env:
@@ -42,4 +44,4 @@ jobs:
           gh release create "$TAG" \
             --title="$TAG" \
             --draft \
-            $DIST_DIR/* "$PLUGIN_NAME-$TAG.zip"
+            "$DIST_DIR/main.js" "$DIST_DIR/manifest.json" "$DIST_DIR/styles.css"

--- a/main.ts
+++ b/main.ts
@@ -56,7 +56,7 @@ const SKIPPED_SYNC_RESULT: SyncResult = {
 
 export default class CloudflareKVPlugin extends Plugin {
   settings: CloudflareKVSettings;
-  private syncTimeouts: Map<string, NodeJS.Timeout> = new Map();
+  private syncTimeouts: Map<string, number> = new Map();
   private syncedFiles: Map<string, string> = new Map();
   private cache: CloudflareKVCache;
   private static cacheFile: string = "cache.json";
@@ -126,10 +126,10 @@ export default class CloudflareKVPlugin extends Plugin {
   private debouncedFileSync(file: TFile) {
     const existingTimeout = this.syncTimeouts.get(file.path);
     if (existingTimeout) {
-      clearTimeout(existingTimeout);
+      activeWindow.clearTimeout(existingTimeout);
     }
 
-    const timeout = setTimeout(() => {
+    const timeout = activeWindow.setTimeout(() => {
       this.syncSingleFile(file)
         .catch((error) => {
           void this.writeErrorLog(
@@ -582,7 +582,7 @@ export default class CloudflareKVPlugin extends Plugin {
 
   private unregisterEvents() {
     for (const timeout of this.syncTimeouts.values()) {
-      clearTimeout(timeout);
+      activeWindow.clearTimeout(timeout);
     }
     this.syncTimeouts.clear();
   }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "cloudflare-kv-sync",
   "name": "Cloudflare KV Sync",
   "version": "0.7.0",
-  "minAppVersion": "1.11.1",
+  "minAppVersion": "1.11.4",
   "description": "Automatically sync tagged Markdown files to Cloudflare KV storage.",
   "author": "Alex Marshall",
   "authorUrl": "https://alxm.me",

--- a/tests/helpers/plugin-test-helper.ts
+++ b/tests/helpers/plugin-test-helper.ts
@@ -38,7 +38,7 @@ export async function createTestPlugin(options?: PluginTestOptions): Promise<Clo
   (plugin as unknown as { manifest: { dir: string } }).manifest = {
     dir: ".obsidian/plugins/cloudflare-kv-sync"
   };
-  (plugin as unknown as { syncTimeouts: Map<string, NodeJS.Timeout> }).syncTimeouts = new Map();
+  (plugin as unknown as { syncTimeouts: Map<string, number> }).syncTimeouts = new Map();
   (plugin as unknown as { syncedFiles: Map<string, string> }).syncedFiles = new Map();
   (plugin as unknown as { loadedSuccesfully: boolean }).loadedSuccesfully = false;
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,6 +8,13 @@ if (!globalThis.crypto?.randomUUID) {
   });
 }
 
+// Obsidian exposes the active window as the `activeWindow` global. In jsdom
+// window === globalThis, so pointing it there makes activeWindow.setTimeout the
+// same function jest.useFakeTimers() patches.
+if (typeof (globalThis as { activeWindow?: unknown }).activeWindow === "undefined") {
+  (globalThis as { activeWindow?: typeof globalThis }).activeWindow = globalThis;
+}
+
 // Extend Jest matchers if needed
 expect.extend({});
 

--- a/tests/unit/constructor.test.ts
+++ b/tests/unit/constructor.test.ts
@@ -1,0 +1,20 @@
+import CloudflareKVPlugin from "../../main";
+import { getPrivateProperty } from "../helpers/plugin-test-helper";
+
+describe("CloudflareKVPlugin field initialization", () => {
+  it("initializes timer, synced-file, and load-state defaults", () => {
+    // Constructed directly (not via createTestPlugin, which bypasses the
+    // constructor) so the class field initializers actually run.
+    const plugin = new CloudflareKVPlugin();
+
+    expect(
+      getPrivateProperty<Map<string, number>>(plugin, "syncTimeouts")
+    ).toEqual(new Map());
+    expect(
+      getPrivateProperty<Map<string, string>>(plugin, "syncedFiles")
+    ).toEqual(new Map());
+    expect(
+      getPrivateProperty<boolean>(plugin, "loadedSuccesfully")
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes the findings from Obsidian's automated plugin review.

## Risks — API/version mismatch
- Bump `minAppVersion` 1.11.1 → 1.11.4 in `manifest.json` to match the `app.secretStorage` / `SecretStorage.getSecret` / `SecretComponent` APIs the plugin uses (those APIs don't exist before 1.11.4). `versions.json` keeps 1.11.1–1.11.3 users on the last compatible release.

## Warnings — popout window compatibility
- Replace bare `setTimeout`/`clearTimeout` with `activeWindow.setTimeout`/`activeWindow.clearTimeout` at all three call sites in `main.ts` so debounced sync works in detached popout windows. `syncTimeouts` Map retyped `number`; added an `activeWindow` polyfill to `tests/setup.ts` for jsdom.

## Warnings — unsupported release assets
- `release.yml` now uploads only `main.js`, `manifest.json`, `styles.css`. Dropped the zip packaging step and `versions.json` from the release assets. `versions.json` stays at the repo root (not deprecated — it's the version→minAppVersion compatibility map).

## Other — missing artifact attestation
- Added `actions/attest-build-provenance@v2` (with `id-token: write` / `attestations: write`) attesting `dist/main.js` and `dist/styles.css`.

## Validation
- Build (tsc + esbuild + assets): pass
- Lint: clean
- Tests: 189/189 pass, coverage 97.4%

## Follow-up
Shipping these requires cutting a new release (0.7.0 is already tagged) — tracked separately. Run `pnpm version <next>` (auto-writes the `versions.json` → 1.11.4 entry), push the tag, then publish the draft and resubmit for review. The attestation only materializes on the real tag-triggered workflow run.