### PR TITLE
Ignore .claude/worktrees/ session worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ coverage/
 .DS_Store
 .DS_Store?
 
+# Claude Code session worktrees
+.claude/worktrees/
+
 # Beads / Dolt files (added by bd init)
 .dolt/
 *.db


### PR DESCRIPTION
Adds `.claude/worktrees/` to `.gitignore`.

Claude Code creates per-session git worktrees under `.claude/worktrees/`. These are local, ephemeral artifacts and were showing up as untracked noise in `git status`. Scoped to the `worktrees/` subdirectory only — `.claude/settings.json` (already tracked) is unaffected.