### PR TITLE
Stop tracking .beads/interactions.jsonl runtime log

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -10,6 +10,9 @@ sync-state.json
 last-touched
 .exclusive-lock
 
+# Interactions log (runtime activity log, not versioned)
+interactions.jsonl
+
 # Daemon runtime (lock, log, pid)
 daemon.*
 


### PR DESCRIPTION
`bd init` (bd 1.0.5) committed `.beads/interactions.jsonl` because its `.beads/.gitignore` template dropped the ignore line that older bd versions wrote. That runtime activity log is rewritten on every `bd` command, so it perpetually dirtied `git status`.

This adds `interactions.jsonl` to `.beads/.gitignore` and untracks it (`git rm --cached`, file kept on disk) — matching the behavior of the sister repo `alexmarshallcounselling.com`.

No effect on beads issues or memory: those live in the Dolt store and sync via `refs/dolt/data`, not these JSONL files.