### PR TITLE
PR 1/3 (a4r): Harden Cloudflare sync path — HTTP errors, URL encoding, batch resilience

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -149,7 +149,19 @@ export default class CloudflareKVPlugin extends Plugin {
       return;
     }
 
-    const syncResult = await this.syncFile(file);
+    let syncResult: SyncResult;
+    try {
+      syncResult = await this.syncFile(file);
+    } catch (error) {
+      // syncFile may throw on a malformed API body or a frontmatter-write
+      // failure; the command/ribbon callbacks fire this with `void`, so an
+      // uncaught rejection would float. Log it and still persist any partial
+      // cache mutation.
+      await this.writeErrorLog(`Error syncing ${file.path}: ${error}`);
+      if (notifyOutcome) new Notice(`Error syncing: ${error}`);
+      await this.saveCache();
+      return;
+    }
     await this.saveCache();
 
     if (syncResult.skipped === true) {
@@ -182,24 +194,31 @@ export default class CloudflareKVPlugin extends Plugin {
     const errorMessages: string[] = [];
 
     for (const file of files) {
-      const syncResult = await this.syncFile(file);
+      try {
+        const syncResult = await this.syncFile(file);
 
-      if (syncResult.skipped === false) {
-        if (syncResult.sync) {
-          if (syncResult.sync.success === true) {
-            successful++;
-          } else {
+        if (syncResult.skipped === false) {
+          if (syncResult.sync) {
+            if (syncResult.sync.success === true) {
+              successful++;
+            } else {
+              failed++;
+              errorMessages.push(
+                `API error syncing ${file.path}: ${syncResult.sync.error}`
+              );
+            }
+          } else if (syncResult.error) {
             failed++;
             errorMessages.push(
-              `API error syncing ${file.path}: ${syncResult.sync.error}`
+              `Sync error for ${file.path}: ${syncResult.error}`
             );
           }
-        } else if (syncResult.error) {
-          failed++;
-          errorMessages.push(
-            `Sync error for ${file.path}: ${syncResult.error}`
-          );
         }
+      } catch (error) {
+        // A single file's failure must not abort the batch or leave the cache
+        // unsaved — route it to the log and keep going.
+        failed++;
+        errorMessages.push(`Unexpected error syncing ${file.path}: ${error}`);
       }
     }
 
@@ -357,23 +376,40 @@ export default class CloudflareKVPlugin extends Plugin {
     return typeof value === "string" && value.trim() !== "" ? value : undefined;
   }
 
+  private encodeKVKeyForUrl(key: string): string {
+    // Cloudflare's /values/:key route captures the path remainder greedily, so
+    // the '/' separating collection and id must stay literal. Encode each
+    // segment on its own — otherwise a space, '#', '?', '%', or unicode char
+    // misroutes/404s. Slash-free ASCII keys are unchanged, so existing data is
+    // not orphaned.
+    return key.split("/").map(encodeURIComponent).join("/");
+  }
+
   private async kvRequest(
     key: string,
     method: "PUT" | "DELETE",
     body?: string
   ): Promise<KVRequestResult> {
-    const url = `https://api.cloudflare.com/client/v4/accounts/${this.settings.accountId}/storage/kv/namespaces/${this.settings.namespaceId}/values/${key}`;
+    const url = `https://api.cloudflare.com/client/v4/accounts/${this.settings.accountId}/storage/kv/namespaces/${this.settings.namespaceId}/values/${this.encodeKVKeyForUrl(key)}`;
     const apiToken = this.app.secretStorage.getSecret(this.settings.apiToken);
 
+    // throw:false — requestUrl throws on HTTP 400+ by default, which would
+    // escape the per-file batch loop. Inspect status and return a structured
+    // result instead.
     const response = await requestUrl({
       url,
       method,
+      throw: false,
       headers: {
         Authorization: `Bearer ${apiToken}`,
         ...(body ? { "Content-Type": "text/plain" } : {})
       },
       ...(body ? { body } : {})
     });
+
+    if (response.status >= 400) {
+      return { success: false, error: this.describeHttpError(response) };
+    }
 
     const raw: unknown = JSON.parse(response.text);
     if (raw && typeof raw === "object" && !Array.isArray(raw)) {
@@ -386,6 +422,23 @@ export default class CloudflareKVPlugin extends Plugin {
     throw new Error(
       `Unexpected response from cloudflare kv API, response body is ${typeof raw}`
     );
+  }
+
+  private describeHttpError(response: {
+    status: number;
+    text: string;
+  }): string {
+    try {
+      const raw: unknown = JSON.parse(response.text);
+      if (raw && typeof raw === "object" && "errors" in raw) {
+        return `HTTP ${response.status}: ${JSON.stringify(
+          (raw as Record<string, unknown>).errors
+        )}`;
+      }
+    } catch {
+      // Non-JSON error body (e.g. an HTML error page) — fall back to status.
+    }
+    return `HTTP ${response.status}`;
   }
 
   private async uploadToKV(

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -168,6 +168,17 @@ export const parseYaml = jest.fn().mockImplementation((yaml: string) => {
       ) {
         value = value.slice(1, -1);
       }
+      // Coerce unquoted numeric scalars to numbers, matching real parseYaml.
+      // This is what makes `id: 123` arrive as a number (which coerceString
+      // rejects) rather than the string "123" — the forgiving old mock hid
+      // that real failure mode.
+      else if (
+        typeof value === "string" &&
+        value.trim() !== "" &&
+        !isNaN(Number(value))
+      ) {
+        value = Number(value);
+      }
 
       result[key] = value;
     }
@@ -177,6 +188,7 @@ export const parseYaml = jest.fn().mockImplementation((yaml: string) => {
 });
 
 export const requestUrl = jest.fn().mockResolvedValue({
+  status: 200,
   text: JSON.stringify({ success: true })
 });
 

--- a/tests/integration/syncAllFiles.test.ts
+++ b/tests/integration/syncAllFiles.test.ts
@@ -243,6 +243,59 @@ describe("syncAllFiles", () => {
     );
   });
 
+  it("should not abort the batch when one file's request throws", async () => {
+    const file1 = createMockTFile("file1.md");
+    const file2 = createMockTFile("file2.md");
+    const file3 = createMockTFile("file3.md");
+
+    (plugin.app.vault.getMarkdownFiles as jest.Mock).mockReturnValue([
+      file1,
+      file2,
+      file3
+    ]);
+    (plugin.app.vault.cachedRead as jest.Mock).mockImplementation(
+      async (file: TFile) => {
+        if (file.path === "file1.md")
+          return "---\nkv_sync: true\nid: id1\n---\n";
+        if (file.path === "file2.md")
+          return "---\nkv_sync: true\nid: id2\n---\n";
+        if (file.path === "file3.md")
+          return "---\nkv_sync: true\nid: id3\n---\n";
+        return "";
+      }
+    );
+    (parseYaml as jest.Mock).mockImplementation((yaml: string) => {
+      if (yaml.includes("id1")) return { kv_sync: true, id: "id1" };
+      if (yaml.includes("id2")) return { kv_sync: true, id: "id2" };
+      if (yaml.includes("id3")) return { kv_sync: true, id: "id3" };
+      return {};
+    });
+
+    // file2's request rejects (network error / requestUrl throw). The batch
+    // must still process file3 and persist the cache.
+    (requestUrl as jest.Mock)
+      .mockResolvedValueOnce(mockSuccessResponse())
+      .mockRejectedValueOnce(new Error("Connection refused"))
+      .mockResolvedValueOnce(mockSuccessResponse());
+
+    await syncAllFiles();
+
+    expect(requestUrl).toHaveBeenCalledTimes(3);
+    expect(noticeMock).toHaveBeenCalledWith(
+      expect.stringContaining("2 successful")
+    );
+    expect(noticeMock).toHaveBeenCalledWith(
+      expect.stringContaining("1 failed")
+    );
+    // Cache persisted despite the mid-batch throw.
+    expect(plugin.app.vault.adapter.write).toHaveBeenCalled();
+    // The throwing file was logged.
+    expect(plugin.app.vault.adapter.write).toHaveBeenCalledWith(
+      "Cloudflare KV Sync error log.md",
+      expect.stringContaining("file2.md")
+    );
+  });
+
   it("should count as failed when key change deletion fails (error path without sync result)", async () => {
     const file1 = createMockTFile("file1.md");
 

--- a/tests/integration/syncFile.test.ts
+++ b/tests/integration/syncFile.test.ts
@@ -104,6 +104,40 @@ describe("syncFile", () => {
       expect(plugin.app.fileManager.processFrontMatter).toHaveBeenCalled();
     });
 
+    it("should treat a numeric id as missing and auto-assign a string id", async () => {
+      // Real parseYaml turns `id: 123` into the number 123, which coerceString
+      // rejects — so the file is treated as having no usable id and gets a
+      // generated one. The forgiving old parseYaml mock (string "123") hid this.
+      const file = createMockTFile("test.md");
+      (plugin.app.vault.cachedRead as jest.Mock)
+        .mockResolvedValueOnce("---\nkv_sync: true\nid: 123\n---\nContent")
+        .mockResolvedValueOnce(
+          `---\nkv_sync: true\nid: ${GENERATED_UUID}\n---\nContent`
+        )
+        .mockResolvedValueOnce(
+          `---\nkv_sync: true\nid: ${GENERATED_UUID}\n---\nContent`
+        );
+      (parseYaml as jest.Mock)
+        .mockReturnValueOnce({ kv_sync: true, id: 123 })
+        .mockReturnValueOnce({ kv_sync: true, id: GENERATED_UUID });
+      (
+        plugin.app.fileManager.processFrontMatter as jest.Mock
+      ).mockResolvedValue(undefined);
+      (requestUrl as jest.Mock).mockResolvedValue(mockSuccessResponse());
+
+      const result = await syncFile(file);
+
+      expect(result.skipped).toBe(false);
+      expect(result.sync?.success).toBe(true);
+      expect(plugin.app.fileManager.processFrontMatter).toHaveBeenCalled();
+      // Synced under the generated string id, never under "123".
+      expect(requestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining(`/values/${GENERATED_UUID}`)
+        })
+      );
+    });
+
     it("should auto-assign ID when id is empty string", async () => {
       const file = createMockTFile("test.md");
       (plugin.app.vault.cachedRead as jest.Mock)

--- a/tests/mocks/cloudflare-mocks.ts
+++ b/tests/mocks/cloudflare-mocks.ts
@@ -3,23 +3,59 @@
 /**
  * Creates a successful Cloudflare API response
  */
-export function mockSuccessResponse(): { text: string } {
+export function mockSuccessResponse(): { status: number; text: string } {
   return {
+    status: 200,
     text: JSON.stringify({ success: true })
   };
 }
 
 /**
- * Creates a Cloudflare API error response
+ * Creates a Cloudflare API error response with an HTTP 200 status but a
+ * success:false body. This models the rare structured-error case; most real
+ * failures (auth, missing key) come back as HTTP 4xx — see
+ * mockHttpErrorResponse.
  */
 export function mockErrorResponse(
   errors: Array<{ code: number; message: string }>
-): { text: string } {
+): { status: number; text: string } {
   return {
+    status: 200,
     text: JSON.stringify({
       success: false,
       errors
     })
+  };
+}
+
+/**
+ * Creates a real Cloudflare HTTP error response (status 400+). The production
+ * requestUrl throws on these by default; the plugin passes throw:false and
+ * inspects the status, so the mock must carry one.
+ */
+export function mockHttpErrorResponse(
+  status: number,
+  errors: Array<{ code: number; message: string }> = [
+    { code: status, message: `HTTP ${status}` }
+  ]
+): { status: number; text: string } {
+  return {
+    status,
+    text: JSON.stringify({ success: false, errors })
+  };
+}
+
+/**
+ * Creates an HTTP error response whose body is not JSON (e.g. an HTML error
+ * page from an edge proxy), to exercise the non-JSON error path.
+ */
+export function mockHttpErrorResponseNonJson(status: number): {
+  status: number;
+  text: string;
+} {
+  return {
+    status,
+    text: "<html><body>Bad gateway</body></html>"
   };
 }
 
@@ -33,8 +69,9 @@ export function mockNetworkError(message: string = "Network error"): Error {
 /**
  * Creates an invalid JSON response
  */
-export function mockInvalidJsonResponse(): { text: string } {
+export function mockInvalidJsonResponse(): { status: number; text: string } {
   return {
+    status: 200,
     text: "Not valid JSON"
   };
 }
@@ -42,8 +79,9 @@ export function mockInvalidJsonResponse(): { text: string } {
 /**
  * Creates an unexpected array response
  */
-export function mockArrayResponse(): { text: string } {
+export function mockArrayResponse(): { status: number; text: string } {
   return {
+    status: 200,
     text: JSON.stringify([{ unexpected: "array" }])
   };
 }
@@ -51,8 +89,12 @@ export function mockArrayResponse(): { text: string } {
 /**
  * Creates a mock response with custom data
  */
-export function mockCustomResponse(data: unknown): { text: string } {
+export function mockCustomResponse(data: unknown): {
+  status: number;
+  text: string;
+} {
   return {
+    status: 200,
     text: JSON.stringify(data)
   };
 }

--- a/tests/unit/debounce.test.ts
+++ b/tests/unit/debounce.test.ts
@@ -156,10 +156,12 @@ describe("debouncedFileSync", () => {
 
     await jest.advanceTimersByTimeAsync(60000);
 
-    // Should have written to error log
+    // Should have written to error log. syncSingleFile now catches the failure
+    // internally (so the command/ribbon callbacks can't leak an unhandled
+    // rejection) and logs it, rather than rejecting up to the debounced catch.
     expect(plugin.app.vault.adapter.write).toHaveBeenCalledWith(
       "Cloudflare KV Sync error log.md",
-      expect.stringContaining("Error in debounced sync of test.md")
+      expect.stringContaining("Error syncing test.md")
     );
   });
 

--- a/tests/unit/kvRequest.test.ts
+++ b/tests/unit/kvRequest.test.ts
@@ -9,7 +9,9 @@ import {
   mockErrorResponse,
   mockInvalidJsonResponse,
   mockArrayResponse,
-  mockNetworkError
+  mockNetworkError,
+  mockHttpErrorResponse,
+  mockHttpErrorResponseNonJson
 } from "../mocks/cloudflare-mocks";
 
 type KVRequestResult = { success: true } | { success: false; error: string };
@@ -37,6 +39,7 @@ describe("kvRequest", () => {
       expect(requestUrl).toHaveBeenCalledWith({
         url: expect.stringContaining("/values/test-key"),
         method: "PUT",
+        throw: false,
         headers: {
           Authorization: "Bearer test-token",
           "Content-Type": "text/plain"
@@ -101,6 +104,7 @@ describe("kvRequest", () => {
       expect(requestUrl).toHaveBeenCalledWith({
         url: expect.stringContaining("/values/test-key"),
         method: "DELETE",
+        throw: false,
         headers: {
           Authorization: "Bearer test-token"
         }
@@ -169,8 +173,60 @@ describe("kvRequest", () => {
     });
   });
 
+  describe("HTTP status handling", () => {
+    it("should pass throw:false so requestUrl does not throw on 4xx", async () => {
+      (requestUrl as jest.Mock).mockResolvedValue(mockSuccessResponse());
+
+      await kvRequest("test-key", "PUT", "content");
+
+      expect(requestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({ throw: false })
+      );
+    });
+
+    it("should return a failure result (not throw) on HTTP 401", async () => {
+      (requestUrl as jest.Mock).mockResolvedValue(
+        mockHttpErrorResponse(401, [
+          { code: 10000, message: "Authentication error" }
+        ])
+      );
+
+      const result = await kvRequest("test-key", "PUT", "content");
+
+      expect(result.success).toBe(false);
+      if (result.success === false) {
+        expect(result.error).toContain("401");
+        expect(result.error).toContain("Authentication error");
+      }
+    });
+
+    it("should return a failure result on HTTP 404 for DELETE", async () => {
+      (requestUrl as jest.Mock).mockResolvedValue(mockHttpErrorResponse(404));
+
+      const result = await kvRequest("missing-key", "DELETE");
+
+      expect(result.success).toBe(false);
+      if (result.success === false) {
+        expect(result.error).toContain("404");
+      }
+    });
+
+    it("should return a failure result on HTTP 500 with a non-JSON body", async () => {
+      (requestUrl as jest.Mock).mockResolvedValue(
+        mockHttpErrorResponseNonJson(500)
+      );
+
+      const result = await kvRequest("test-key", "PUT", "content");
+
+      expect(result.success).toBe(false);
+      if (result.success === false) {
+        expect(result.error).toContain("500");
+      }
+    });
+  });
+
   describe("URL encoding", () => {
-    it("should handle keys with special characters", async () => {
+    it("should keep the collection/id slash literal", async () => {
       (requestUrl as jest.Mock).mockResolvedValue(mockSuccessResponse());
 
       await kvRequest("posts/my-doc-123", "PUT", "content");
@@ -180,6 +236,38 @@ describe("kvRequest", () => {
           url: expect.stringContaining("/values/posts/my-doc-123")
         })
       );
+    });
+
+    it("should leave existing slash-only ASCII keys byte-identical", async () => {
+      (requestUrl as jest.Mock).mockResolvedValue(mockSuccessResponse());
+
+      await kvRequest("path/to/doc", "PUT", "content");
+
+      expect(requestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining("/values/path/to/doc")
+        })
+      );
+    });
+
+    it("should percent-encode special characters within each segment", async () => {
+      (requestUrl as jest.Mock).mockResolvedValue(mockSuccessResponse());
+
+      await kvRequest("writing/my post #1", "PUT", "content");
+
+      const url = (requestUrl as jest.Mock).mock.calls[0][0].url as string;
+      // Separator '/' stays literal; the space and '#' are encoded.
+      expect(url).toContain("/values/writing/my%20post%20%231");
+      expect(url).not.toContain("my post #1");
+    });
+
+    it("should encode unicode key segments", async () => {
+      (requestUrl as jest.Mock).mockResolvedValue(mockSuccessResponse());
+
+      await kvRequest("café", "DELETE");
+
+      const url = (requestUrl as jest.Mock).mock.calls[0][0].url as string;
+      expect(url).toContain("/values/caf%C3%A9");
     });
   });
 });


### PR DESCRIPTION
First of three PRs shipping the **a4r** code-quality epic. This cluster bundles the three findings that share the request/sync path **and the test-harness work that exposes them** — they cannot be cleanly separated (the encoding test and the 4xx/throw mocks are the proof for the fixes).

Closes `obsidian-cloudflare-kv-sync-9uw`, `obsidian-cloudflare-kv-sync-waz`, `obsidian-cloudflare-kv-sync-665`.

## Why these ship together
The root cause the review identified: tests ran against forgiving fakes. The `requestUrl` mock always resolved success, never reflected status, and ignored the URL; `parseYaml` didn't coerce numbers. So real API-contract violations shipped green. Fixing the harness (665) is what makes the other two testable.

## Changes

### 9uw — requestUrl throws on 4xx; batch loops didn't catch
- `kvRequest` now passes `throw: false` and inspects `response.status` (400+ → structured `{success:false}` with a `describeHttpError` summary that tolerates non-JSON bodies). Previously a 401/404/500 *threw*.
- `syncAllFiles` wraps each per-file sync in try/catch: one failure is logged + counted, never aborts the batch, and the cache is always saved.
- `syncSingleFile` catches internally so the command/ribbon callbacks (`void this.syncSingleFile(...)`) can't leak an unhandled rejection; partial cache mutations still persist.

### waz — URL-encode KV key segments (back-compat preserved)
- New `encodeKVKeyForUrl`: splits the key on `/`, `encodeURIComponent`s each segment, rejoins with literal `/`. Keys with spaces/`#`/`?`/`%`/unicode now route correctly.
- **Back-compat:** done at the URL layer, not in `buildKVKey`, so the cache keeps storing logical keys and **existing slash-keys (including slashes inside an id) stay byte-identical** — no orphaned vault data. All existing `buildKVKey` tests pass unchanged.

### 665 — mocks model real failure modes
- `requestUrl` mock can return real 4xx (`mockHttpErrorResponse`) and non-JSON error bodies (`mockHttpErrorResponseNonJson`); response factories carry a `status`.
- `parseYaml` mock coerces unquoted numeric scalars to numbers, matching the real parser — so `id: 123` arrives as a number that `coerceString` rejects (the file is treated as having no usable id and is auto-assigned a UUID).
- Added: URL-encoding assertions, HTTP-status handling tests, a batch-resilience test (mid-batch throw doesn't abort), and a numeric-id test.

## Validation
- `pnpm test` — 199 passed (16 suites); coverage 97.9% stmts / 93.3% branch, above the 90% gate
- `pnpm lint` — clean
- `pnpm build` — typecheck + bundle clean
- `prettier --check` — clean

## Notes
- Two existing `kvRequest` assertions were updated to include `throw: false`; one debounce test now asserts the error is logged via `syncSingleFile` (which now catches) rather than the debounced wrapper.
- Follow-ups in the epic: **PR 2** (runtime bugs + DRY + strict null checks), **PR 3** (docs/UI/release drift, gated on the `post-plugin-acceptance` merge).