### PR TITLE
Fix sync-all race, auto-sync toggle, NaN delay; DRY + strict null checks (a4r PR 2)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -12,6 +12,10 @@ import {
 
 const ERROR_LOG_FILE = "Cloudflare KV Sync error log.md";
 
+// Cap the error log so a misconfigured auto-sync can't balloon a vault file.
+// At the cap we keep roughly the newest half; normal writes just append.
+const MAX_ERROR_LOG_BYTES = 1_000_000;
+
 interface CloudflareKVSettings {
   accountId: string;
   namespaceId: string;
@@ -54,38 +58,59 @@ const SKIPPED_SYNC_RESULT: SyncResult = {
   skipped: true
 };
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Accumulates per-item results for a batch operation (sync-all, orphan cleanup)
+// so the surrounding method doesn't hand-roll the success/failure/error tally.
+class BatchOutcome {
+  successful = 0;
+  failed = 0;
+  readonly errors: string[] = [];
+
+  recordSuccess(): void {
+    this.successful++;
+  }
+
+  recordFailure(message: string): void {
+    this.failed++;
+    this.errors.push(message);
+  }
+}
+
 export default class CloudflareKVPlugin extends Plugin {
-  settings: CloudflareKVSettings;
+  settings!: CloudflareKVSettings;
   private syncTimeouts: Map<string, number> = new Map();
   private syncedFiles: Map<string, string> = new Map();
-  private cache: CloudflareKVCache;
   private static cacheFile: string = "cache.json";
-  private loadedSuccesfully: boolean = false;
+  private loadedSuccessfully: boolean = false;
+
+  private get cachePath(): string {
+    return `${this.manifest.dir}/${CloudflareKVPlugin.cacheFile}`;
+  }
 
   async onload() {
     try {
       await this.loadSettings();
       await this.loadCache();
       this.addSettingTab(new CloudflareKVSettingsTab(this.app, this));
-      this.loadedSuccesfully = true;
+      this.loadedSuccessfully = true;
     } catch (e) {
       new Notice(
         "Cloudflare kv sync plugin failed to load. See error log for details."
       );
-      void this.writeErrorLog(`Plugin failed to load: ${e}`);
+      void this.writeErrorLog(`Plugin failed to load: ${String(e)}`);
       return;
     }
 
-    if (this.loadedSuccesfully) {
-      this.registerCommands();
-      this.registerEvents();
-    }
+    this.registerCommands();
+    this.registerEvents();
   }
 
   private registerCommands() {
     this.addRibbonIcon("cloud-upload", "Sync to cloudflare kv", () => {
-      void this.syncAllFiles();
-      void this.removeOrphanedUploads();
+      void this.syncAllAndCleanup();
     });
 
     this.addCommand({
@@ -105,22 +130,33 @@ export default class CloudflareKVPlugin extends Plugin {
       id: "sync-all-files-to-kv",
       name: "Sync all marked files to cloudflare kv",
       callback: () => {
-        void this.syncAllFiles();
-        void this.removeOrphanedUploads();
+        void this.syncAllAndCleanup();
       }
     });
   }
 
+  // Sync-all and orphan cleanup both mutate syncedFiles and write cache.json.
+  // They must run sequentially — concurrent runs corrupt the map mid-iteration
+  // and race the cache write (last-writer-wins).
+  private async syncAllAndCleanup(): Promise<void> {
+    await this.syncAllFiles();
+    await this.removeOrphanedUploads();
+  }
+
   private registerEvents() {
-    if (this.settings.autoSync) {
-      this.registerEvent(
-        this.app.vault.on("modify", (file) => {
-          if (file instanceof TFile && file.extension === "md") {
-            this.debouncedFileSync(file);
-          }
-        })
-      );
-    }
+    // Register unconditionally and gate on the live setting inside the handler,
+    // so toggling auto-sync takes effect immediately without a plugin reload.
+    this.registerEvent(
+      this.app.vault.on("modify", (file) => {
+        if (
+          this.settings.autoSync &&
+          file instanceof TFile &&
+          file.extension === "md"
+        ) {
+          this.debouncedFileSync(file);
+        }
+      })
+    );
   }
 
   private debouncedFileSync(file: TFile) {
@@ -133,7 +169,7 @@ export default class CloudflareKVPlugin extends Plugin {
       this.syncSingleFile(file)
         .catch((error) => {
           void this.writeErrorLog(
-            `Error in debounced sync of ${file.path}: ${error}`
+            `Error in debounced sync of ${file.path}: ${String(error)}`
           );
         })
         .finally(() => {
@@ -157,8 +193,8 @@ export default class CloudflareKVPlugin extends Plugin {
       // failure; the command/ribbon callbacks fire this with `void`, so an
       // uncaught rejection would float. Log it and still persist any partial
       // cache mutation.
-      await this.writeErrorLog(`Error syncing ${file.path}: ${error}`);
-      if (notifyOutcome) new Notice(`Error syncing: ${error}`);
+      await this.writeErrorLog(`Error syncing ${file.path}: ${String(error)}`);
+      if (notifyOutcome) new Notice(`Error syncing: ${String(error)}`);
       await this.saveCache();
       return;
     }
@@ -189,9 +225,7 @@ export default class CloudflareKVPlugin extends Plugin {
 
     await this.detectAndFixDuplicates(files);
 
-    let successful = 0;
-    let failed = 0;
-    const errorMessages: string[] = [];
+    const outcome = new BatchOutcome();
 
     for (const file of files) {
       try {
@@ -200,16 +234,14 @@ export default class CloudflareKVPlugin extends Plugin {
         if (syncResult.skipped === false) {
           if (syncResult.sync) {
             if (syncResult.sync.success === true) {
-              successful++;
+              outcome.recordSuccess();
             } else {
-              failed++;
-              errorMessages.push(
+              outcome.recordFailure(
                 `API error syncing ${file.path}: ${syncResult.sync.error}`
               );
             }
           } else if (syncResult.error) {
-            failed++;
-            errorMessages.push(
+            outcome.recordFailure(
               `Sync error for ${file.path}: ${syncResult.error}`
             );
           }
@@ -217,18 +249,34 @@ export default class CloudflareKVPlugin extends Plugin {
       } catch (error) {
         // A single file's failure must not abort the batch or leave the cache
         // unsaved — route it to the log and keep going.
-        failed++;
-        errorMessages.push(`Unexpected error syncing ${file.path}: ${error}`);
+        outcome.recordFailure(
+          `Unexpected error syncing ${file.path}: ${String(error)}`
+        );
       }
     }
 
+    await this.finishBatch(outcome, "Sync complete", true);
+  }
+
+  // Persists the cache, logs any accumulated errors, and surfaces a summary
+  // notice — the shared tail of every batch operation. `notifyWhenEmpty`
+  // controls whether the notice fires when nothing was processed.
+  private async finishBatch(
+    outcome: BatchOutcome,
+    completeLabel: string,
+    notifyWhenEmpty: boolean
+  ): Promise<void> {
     await this.saveCache();
 
-    if (errorMessages.length > 0) {
-      await this.writeErrorLog(errorMessages);
+    if (outcome.errors.length > 0) {
+      await this.writeErrorLog(outcome.errors);
     }
 
-    new Notice(`ℹ️ Sync complete: ${successful} successful, ${failed} failed`);
+    if (notifyWhenEmpty || outcome.successful > 0 || outcome.failed > 0) {
+      new Notice(
+        `ℹ️ ${completeLabel}: ${outcome.successful} successful, ${outcome.failed} failed`
+      );
+    }
   }
 
   private async syncFile(file: TFile): Promise<SyncResult> {
@@ -276,6 +324,13 @@ export default class CloudflareKVPlugin extends Plugin {
     // File is marked for sync (syncValue guaranteed true at this point)
     result.skipped = false;
 
+    if (!currentKVKey) {
+      // docId is guaranteed above, so buildKVKey only returns null on a
+      // malformed frontmatter race; fail loudly rather than PUT a null key.
+      result.error = `Unable to build KV key for ${file.name}`;
+      return result;
+    }
+
     if (previousKVKey && previousKVKey !== currentKVKey) {
       // File's sync key has changed
       const deleteResult = await this.deleteFromKV(previousKVKey);
@@ -303,34 +358,21 @@ export default class CloudflareKVPlugin extends Plugin {
         entriesToRemove.push({ filePath, kvKey });
     }
 
-    let successful = 0;
-    let failed = 0;
-    const errorMessages: string[] = [];
+    const outcome = new BatchOutcome();
 
     for (const { filePath, kvKey } of entriesToRemove) {
       const result = await this.deleteFromKV(kvKey);
       if (result.success === true) {
-        successful++;
+        outcome.recordSuccess();
         this.syncedFiles.delete(filePath);
       } else {
-        failed++;
-        errorMessages.push(
+        outcome.recordFailure(
           `API error removing orphan ${kvKey}: ${result.error}`
         );
       }
     }
 
-    await this.saveCache();
-
-    if (errorMessages.length > 0) {
-      await this.writeErrorLog(errorMessages);
-    }
-
-    if (successful > 0 || failed > 0) {
-      new Notice(
-        `ℹ️ Cleanup complete: ${successful} successful, ${failed} failed`
-      );
-    }
+    await this.finishBatch(outcome, "Cleanup complete", false);
   }
 
   private async getFrontmatter(
@@ -344,23 +386,25 @@ export default class CloudflareKVPlugin extends Plugin {
 
       try {
         const raw: unknown = parseYaml(frontmatterMatch[1]);
-        if (raw && typeof raw === "object" && !Array.isArray(raw))
-          return raw as Record<string, unknown>;
+        if (isPlainObject(raw)) return raw;
         return null;
       } catch (error) {
         void this.writeErrorLog(
-          `Error parsing frontmatter in ${file.name}: ${error}`
+          `Error parsing frontmatter in ${file.name}: ${String(error)}`
         );
         return null;
       }
     } catch (error) {
-      void this.writeErrorLog(`Error reading file ${file.name}: ${error}`);
+      void this.writeErrorLog(
+        `Error reading file ${file.name}: ${String(error)}`
+      );
       return null;
     }
   }
 
   private buildKVKey(frontmatter: Record<string, unknown>): string | null {
     const docId = this.coerceString(frontmatter[this.settings.idKey]);
+    if (!docId) return null;
     const collection = this.coerceString(frontmatter["collection"]);
 
     return collection ? `${collection}/${docId}` : docId;
@@ -412,10 +456,9 @@ export default class CloudflareKVPlugin extends Plugin {
     }
 
     const raw: unknown = JSON.parse(response.text);
-    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
-      const data = raw as Record<string, unknown>;
-      if (!data.success) {
-        return { success: false, error: `${JSON.stringify(data.errors)}` };
+    if (isPlainObject(raw)) {
+      if (!raw.success) {
+        return { success: false, error: `${JSON.stringify(raw.errors)}` };
       }
       return { success: true };
     }
@@ -430,10 +473,8 @@ export default class CloudflareKVPlugin extends Plugin {
   }): string {
     try {
       const raw: unknown = JSON.parse(response.text);
-      if (raw && typeof raw === "object" && "errors" in raw) {
-        return `HTTP ${response.status}: ${JSON.stringify(
-          (raw as Record<string, unknown>).errors
-        )}`;
+      if (isPlainObject(raw) && "errors" in raw) {
+        return `HTTP ${response.status}: ${JSON.stringify(raw.errors)}`;
       }
     } catch {
       // Non-JSON error body (e.g. an HTML error page) — fall back to status.
@@ -458,20 +499,30 @@ export default class CloudflareKVPlugin extends Plugin {
     };
   }
 
+  // Validates that persisted JSON is an object and merges it over the defaults.
+  // `describeInvalid` builds the caller-specific error for non-object payloads.
+  private mergeWithDefaults<T extends object>(
+    raw: unknown,
+    defaults: T,
+    describeInvalid: (type: string) => string
+  ): T {
+    if (!isPlainObject(raw)) {
+      throw new Error(describeInvalid(typeof raw));
+    }
+    return Object.assign({}, defaults, raw);
+  }
+
   private async loadSettings() {
     const raw: unknown = await this.loadData();
-    if (raw === null) {
-      this.settings = Object.assign({}, DEFAULT_SETTINGS);
-    } else {
-      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
-        const settingsData = raw as Record<string, unknown>;
-        this.settings = Object.assign({}, DEFAULT_SETTINGS, settingsData);
-      } else {
-        throw new Error(
-          `Unexpected response from settings data load, loadData response is ${typeof raw}`
-        );
-      }
-    }
+    this.settings =
+      raw === null
+        ? Object.assign({}, DEFAULT_SETTINGS)
+        : this.mergeWithDefaults(
+            raw,
+            DEFAULT_SETTINGS,
+            (type) =>
+              `Unexpected response from settings data load, loadData response is ${type}`
+          );
   }
 
   async saveSettings() {
@@ -502,42 +553,39 @@ export default class CloudflareKVPlugin extends Plugin {
   }
 
   private async loadCache() {
-    const cacheFile = `${this.manifest.dir}/${CloudflareKVPlugin.cacheFile}`;
+    let syncedFiles: Record<string, string> = {};
 
-    if (await this.app.vault.adapter.exists(cacheFile)) {
-      const cacheData = await this.app.vault.adapter.read(cacheFile);
-      const raw: unknown = JSON.parse(cacheData);
-      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
-        const parsed = raw as Record<string, unknown>;
-        this.cache = Object.assign({}, DEFAULT_CACHE, parsed);
-      } else {
-        throw new Error(
-          `Unable to parse cache file, parsed object was type ${typeof raw}`
-        );
-      }
-    } else {
-      this.cache = Object.assign({}, DEFAULT_CACHE);
+    if (await this.app.vault.adapter.exists(this.cachePath)) {
+      const raw: unknown = JSON.parse(
+        await this.app.vault.adapter.read(this.cachePath)
+      );
+      const cache = this.mergeWithDefaults(
+        raw,
+        DEFAULT_CACHE,
+        (type) => `Unable to parse cache file, parsed object was type ${type}`
+      );
+      syncedFiles = cache.syncedFiles;
     }
 
     try {
-      this.syncedFiles = new Map(Object.entries(this.cache.syncedFiles));
+      this.syncedFiles = new Map(Object.entries(syncedFiles));
       /* istanbul ignore next */
     } catch (e) {
-      throw new Error(`Failed to read cached data: ${e}`);
+      throw new Error(`Failed to read cached data: ${String(e)}`);
     }
   }
 
   private async saveCache() {
     try {
-      this.cache.syncedFiles = Object.fromEntries(this.syncedFiles);
-
-      const cacheJson = JSON.stringify(this.cache, null, 2);
+      const cache: CloudflareKVCache = {
+        syncedFiles: Object.fromEntries(this.syncedFiles)
+      };
       await this.app.vault.adapter.write(
-        `${this.manifest.dir}/${CloudflareKVPlugin.cacheFile}`,
-        cacheJson
+        this.cachePath,
+        JSON.stringify(cache, null, 2)
       );
     } catch (error) {
-      await this.writeErrorLog(`Error saving cache: ${error}`);
+      await this.writeErrorLog(`Error saving cache: ${String(error)}`);
     }
   }
 
@@ -554,16 +602,36 @@ export default class CloudflareKVPlugin extends Plugin {
     const lines = Array.isArray(messages) ? messages : [messages];
     const entry = `${this.formatErrorLogHeader()}${lines.map((m) => `- ${m}`).join("\n")}\n`;
 
+    const adapter = this.app.vault.adapter;
     try {
-      if (await this.app.vault.adapter.exists(ERROR_LOG_FILE)) {
-        const existing = await this.app.vault.adapter.read(ERROR_LOG_FILE);
-        await this.app.vault.adapter.write(ERROR_LOG_FILE, existing + entry);
+      if (!(await adapter.exists(ERROR_LOG_FILE))) {
+        await adapter.write(ERROR_LOG_FILE, entry);
+        return;
+      }
+
+      // Hot path: append in O(1) — no full-file read. Only when the log
+      // crosses the cap do we pay a read+rewrite to drop the oldest entries.
+      const stat = await adapter.stat(ERROR_LOG_FILE);
+      if (stat && stat.size > MAX_ERROR_LOG_BYTES) {
+        const existing = await adapter.read(ERROR_LOG_FILE);
+        await adapter.write(
+          ERROR_LOG_FILE,
+          this.trimErrorLog(existing) + entry
+        );
       } else {
-        await this.app.vault.adapter.write(ERROR_LOG_FILE, entry);
+        await adapter.append(ERROR_LOG_FILE, entry);
       }
     } catch (error) {
       console.error("Failed to write error log:", error);
     }
+  }
+
+  // Keep roughly the newest half of the log, cut at an entry boundary so the
+  // retained text starts with a whole `## <datetime>` header.
+  private trimErrorLog(existing: string): string {
+    const tail = existing.slice(-Math.floor(MAX_ERROR_LOG_BYTES / 2));
+    const boundary = tail.indexOf("\n## ");
+    return boundary >= 0 ? tail.slice(boundary + 1) : tail;
   }
 
   private generateId(): string {
@@ -622,7 +690,7 @@ export default class CloudflareKVPlugin extends Plugin {
   }
 
   onunload() {
-    if (this.loadedSuccesfully) {
+    if (this.loadedSuccessfully) {
       /* istanbul ignore next */
       this.saveCache().catch(() => {});
       this.unregisterEvents();
@@ -741,7 +809,13 @@ class CloudflareKVSettingsTab extends PluginSettingTab {
           .setPlaceholder(DEFAULT_SETTINGS.debounceDelay.toString())
           .setValue(this.plugin.settings.debounceDelay.toString())
           .onChange(async (value) => {
-            this.plugin.settings.debounceDelay = parseInt(value);
+            const parsed = parseInt(value, 10);
+            // NaN or negative input would make setTimeout fire immediately;
+            // fall back to the default delay instead.
+            this.plugin.settings.debounceDelay =
+              Number.isFinite(parsed) && parsed >= 0
+                ? parsed
+                : DEFAULT_SETTINGS.debounceDelay;
             await this.plugin.saveSettings();
           })
       );

--- a/main.ts
+++ b/main.ts
@@ -569,8 +569,8 @@ export default class CloudflareKVPlugin extends Plugin {
 
     try {
       this.syncedFiles = new Map(Object.entries(syncedFiles));
-      /* istanbul ignore next */
     } catch (e) {
+      /* istanbul ignore next -- Object.entries/new Map can't throw on a validated record */
       throw new Error(`Failed to read cached data: ${String(e)}`);
     }
   }

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -84,6 +84,8 @@ export class DataAdapter {
   exists = jest.fn().mockResolvedValue(false);
   read = jest.fn().mockResolvedValue("");
   write = jest.fn().mockResolvedValue(undefined);
+  append = jest.fn().mockResolvedValue(undefined);
+  stat = jest.fn().mockResolvedValue({ size: 0 });
 }
 
 export class Workspace {

--- a/tests/helpers/plugin-test-helper.ts
+++ b/tests/helpers/plugin-test-helper.ts
@@ -48,7 +48,7 @@ export async function createTestPlugin(
     new Map();
   (plugin as unknown as { syncedFiles: Map<string, string> }).syncedFiles =
     new Map();
-  (plugin as unknown as { loadedSuccesfully: boolean }).loadedSuccesfully =
+  (plugin as unknown as { loadedSuccessfully: boolean }).loadedSuccessfully =
     false;
 
   // Mock loadData and saveData

--- a/tests/integration/syncAllFiles.test.ts
+++ b/tests/integration/syncAllFiles.test.ts
@@ -289,8 +289,8 @@ describe("syncAllFiles", () => {
     );
     // Cache persisted despite the mid-batch throw.
     expect(plugin.app.vault.adapter.write).toHaveBeenCalled();
-    // The throwing file was logged.
-    expect(plugin.app.vault.adapter.write).toHaveBeenCalledWith(
+    // The throwing file was logged (appended to the existing error log).
+    expect(plugin.app.vault.adapter.append).toHaveBeenCalledWith(
       "Cloudflare KV Sync error log.md",
       expect.stringContaining("file2.md")
     );

--- a/tests/integration/syncFile.test.ts
+++ b/tests/integration/syncFile.test.ts
@@ -451,6 +451,29 @@ describe("syncFile", () => {
     });
   });
 
+  describe("Unbuildable KV key", () => {
+    it("should error (not upload a null key) when the re-read frontmatter still has no id", async () => {
+      // Frontmatter race: the file is marked for sync with no id, so an id is
+      // assigned, but the subsequent re-read still yields no usable id, leaving
+      // buildKVKey null. The guard must fail loudly rather than PUT a null key.
+      const file = createMockTFile("test.md");
+      (plugin.app.vault.cachedRead as jest.Mock).mockResolvedValue(
+        "---\nkv_sync: true\n---\nContent"
+      );
+      (parseYaml as jest.Mock).mockReturnValue({ kv_sync: true });
+      (
+        plugin.app.fileManager.processFrontMatter as jest.Mock
+      ).mockResolvedValue(undefined);
+
+      const result = await syncFile(file);
+
+      expect(result.skipped).toBe(false);
+      expect(result.error).toContain("Unable to build KV key");
+      expect(result.sync).toBeUndefined();
+      expect(requestUrl).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Delete old fails", () => {
     it("should return error and not upload when delete of old key fails", async () => {
       // Pre-populate cache with old collection

--- a/tests/unit/buildKVKey.test.ts
+++ b/tests/unit/buildKVKey.test.ts
@@ -29,16 +29,21 @@ describe("buildKVKey", () => {
     expect(buildKVKey({ id: "abc", collection: "  " })).toBe("abc");
   });
 
-  it("should return undefined when id is missing and no collection", () => {
-    expect(buildKVKey({})).toBeUndefined();
+  it("should return null when id is missing and no collection", () => {
+    expect(buildKVKey({})).toBeNull();
   });
 
-  it("should return undefined when id is empty string and no collection", () => {
-    expect(buildKVKey({ id: "" })).toBeUndefined();
+  it("should return null when id is empty string and no collection", () => {
+    expect(buildKVKey({ id: "" })).toBeNull();
   });
 
-  it("should return undefined when id is whitespace and no collection", () => {
-    expect(buildKVKey({ id: "   " })).toBeUndefined();
+  it("should return null when id is whitespace and no collection", () => {
+    expect(buildKVKey({ id: "   " })).toBeNull();
+  });
+
+  it("should return null when id is missing even if a collection is set", () => {
+    // Guards against producing a "collection/undefined" key.
+    expect(buildKVKey({ collection: "posts" })).toBeNull();
   });
 
   it("should handle complex id values", () => {
@@ -67,7 +72,7 @@ describe("buildKVKey", () => {
   });
 
   it("should ignore non-string id values", () => {
-    expect(buildKVKey({ id: 123 })).toBeUndefined();
+    expect(buildKVKey({ id: 123 })).toBeNull();
   });
 
   it("should ignore non-string collection values", () => {

--- a/tests/unit/constructor.test.ts
+++ b/tests/unit/constructor.test.ts
@@ -13,7 +13,7 @@ describe("CloudflareKVPlugin field initialization", () => {
     expect(
       getPrivateProperty<Map<string, string>>(plugin, "syncedFiles")
     ).toEqual(new Map());
-    expect(getPrivateProperty<boolean>(plugin, "loadedSuccesfully")).toBe(
+    expect(getPrivateProperty<boolean>(plugin, "loadedSuccessfully")).toBe(
       false
     );
   });

--- a/tests/unit/debounce.test.ts
+++ b/tests/unit/debounce.test.ts
@@ -165,6 +165,30 @@ describe("debouncedFileSync", () => {
     );
   });
 
+  it("should log when the debounced sync itself rejects", async () => {
+    // syncSingleFile normally swallows its own errors; if it ever rejects
+    // outright (e.g. an unexpected throw), the debounced wrapper must catch and
+    // log it so the timer callback can't leak an unhandled rejection.
+    const file = createMockTFile("test.md");
+    (plugin.app.vault.adapter.exists as jest.Mock).mockResolvedValue(false);
+    (
+      plugin as unknown as { syncSingleFile: (f: TFile) => Promise<void> }
+    ).syncSingleFile = jest.fn().mockRejectedValue(new Error("boom"));
+
+    const debouncedFileSync = getPrivateMethod<(file: TFile) => void>(
+      plugin,
+      "debouncedFileSync"
+    );
+
+    debouncedFileSync(file);
+    await jest.advanceTimersByTimeAsync(60000);
+
+    expect(plugin.app.vault.adapter.write).toHaveBeenCalledWith(
+      "Cloudflare KV Sync error log.md",
+      expect.stringContaining("Error in debounced sync of test.md")
+    );
+  });
+
   it("should use configured debounce delay", async () => {
     // Change debounce delay to 30 seconds
     plugin.settings.debounceDelay = 30;

--- a/tests/unit/errorLog.test.ts
+++ b/tests/unit/errorLog.test.ts
@@ -69,6 +69,25 @@ describe("writeErrorLog", () => {
     expect(rewritten.length).toBeLessThan(existing.length);
   });
 
+  it("should keep the raw tail when the kept slice spans no entry boundary", async () => {
+    // One giant entry with no `## ` header in the retained tail — the trim
+    // falls back to keeping the slice verbatim rather than dropping everything.
+    (plugin.app.vault.adapter.exists as jest.Mock).mockResolvedValue(true);
+    (plugin.app.vault.adapter.stat as jest.Mock).mockResolvedValue({
+      size: 2_000_000
+    });
+    const existing = "\n## 1 Jan 2020, 00:00:00\n- " + "y".repeat(1_500_000);
+    (plugin.app.vault.adapter.read as jest.Mock).mockResolvedValue(existing);
+
+    await writeErrorLog("New error message");
+
+    const rewritten = (plugin.app.vault.adapter.write as jest.Mock).mock
+      .calls[0][1] as string;
+    expect(rewritten).toContain("- New error message");
+    expect(rewritten).not.toContain("## 1 Jan 2020");
+    expect(rewritten.length).toBeLessThan(existing.length);
+  });
+
   it("should handle array of messages", async () => {
     (plugin.app.vault.adapter.exists as jest.Mock).mockResolvedValue(false);
 

--- a/tests/unit/errorLog.test.ts
+++ b/tests/unit/errorLog.test.ts
@@ -25,22 +25,48 @@ describe("writeErrorLog", () => {
     );
   });
 
-  it("should append to existing error log file", async () => {
+  it("should append (not read+rewrite) to an existing under-cap log", async () => {
     (plugin.app.vault.adapter.exists as jest.Mock).mockResolvedValue(true);
-    (plugin.app.vault.adapter.read as jest.Mock).mockResolvedValue(
-      "\n## 2026-01-01T00:00:00.000Z\n- Previous error\n"
-    );
+    (plugin.app.vault.adapter.stat as jest.Mock).mockResolvedValue({ size: 0 });
+    // createTestPlugin's loadCache already read/wrote cache.json; only care
+    // about calls made by writeErrorLog itself.
+    (plugin.app.vault.adapter.read as jest.Mock).mockClear();
+    (plugin.app.vault.adapter.write as jest.Mock).mockClear();
 
     await writeErrorLog("New error message");
 
-    expect(plugin.app.vault.adapter.write).toHaveBeenCalledWith(
-      "Cloudflare KV Sync error log.md",
-      expect.stringContaining("- Previous error")
-    );
-    expect(plugin.app.vault.adapter.write).toHaveBeenCalledWith(
+    // Hot path appends in O(1) — no full-file read or rewrite.
+    expect(plugin.app.vault.adapter.append).toHaveBeenCalledWith(
       "Cloudflare KV Sync error log.md",
       expect.stringContaining("- New error message")
     );
+    expect(plugin.app.vault.adapter.read).not.toHaveBeenCalled();
+    expect(plugin.app.vault.adapter.write).not.toHaveBeenCalled();
+  });
+
+  it("should rotate the log when it exceeds the size cap", async () => {
+    (plugin.app.vault.adapter.exists as jest.Mock).mockResolvedValue(true);
+    (plugin.app.vault.adapter.stat as jest.Mock).mockResolvedValue({
+      size: 2_000_000
+    });
+    // Oldest entry should be dropped; a more recent one kept.
+    const existing =
+      "\n## 1 Jan 2020, 00:00:00\n- Ancient error\n" +
+      "x".repeat(1_500_000) +
+      "\n## 2 Jan 2020, 00:00:00\n- Recent error\n";
+    (plugin.app.vault.adapter.read as jest.Mock).mockResolvedValue(existing);
+
+    await writeErrorLog("New error message");
+
+    expect(plugin.app.vault.adapter.append).not.toHaveBeenCalled();
+    const rewritten = (plugin.app.vault.adapter.write as jest.Mock).mock
+      .calls[0][1] as string;
+    expect(rewritten).toContain("- Recent error");
+    expect(rewritten).toContain("- New error message");
+    expect(rewritten).not.toContain("- Ancient error");
+    // Trimmed content starts at a whole entry header.
+    expect(rewritten.startsWith("## ")).toBe(true);
+    expect(rewritten.length).toBeLessThan(existing.length);
   });
 
   it("should handle array of messages", async () => {

--- a/tests/unit/lifecycle.test.ts
+++ b/tests/unit/lifecycle.test.ts
@@ -47,8 +47,8 @@ describe("Plugin lifecycle", () => {
         freshPlugin as unknown as { syncedFiles: Map<string, string> }
       ).syncedFiles = new Map();
       (
-        freshPlugin as unknown as { loadedSuccesfully: boolean }
-      ).loadedSuccesfully = false;
+        freshPlugin as unknown as { loadedSuccessfully: boolean }
+      ).loadedSuccessfully = false;
 
       freshPlugin.loadData = jest.fn().mockResolvedValue({
         accountId: "test",
@@ -65,8 +65,8 @@ describe("Plugin lifecycle", () => {
 
       expect(freshPlugin.addSettingTab).toHaveBeenCalled();
       expect(
-        (freshPlugin as unknown as { loadedSuccesfully: boolean })
-          .loadedSuccesfully
+        (freshPlugin as unknown as { loadedSuccessfully: boolean })
+          .loadedSuccessfully
       ).toBe(true);
     });
 
@@ -87,8 +87,8 @@ describe("Plugin lifecycle", () => {
         freshPlugin as unknown as { syncedFiles: Map<string, string> }
       ).syncedFiles = new Map();
       (
-        freshPlugin as unknown as { loadedSuccesfully: boolean }
-      ).loadedSuccesfully = false;
+        freshPlugin as unknown as { loadedSuccessfully: boolean }
+      ).loadedSuccessfully = false;
 
       // Make loadData throw
       freshPlugin.loadData = jest
@@ -108,8 +108,8 @@ describe("Plugin lifecycle", () => {
         expect.stringContaining("failed to load")
       );
       expect(
-        (freshPlugin as unknown as { loadedSuccesfully: boolean })
-          .loadedSuccesfully
+        (freshPlugin as unknown as { loadedSuccessfully: boolean })
+          .loadedSuccessfully
       ).toBe(false);
       // Should not register commands on failure
       expect(freshPlugin.addRibbonIcon).not.toHaveBeenCalled();
@@ -132,8 +132,8 @@ describe("Plugin lifecycle", () => {
         freshPlugin as unknown as { syncedFiles: Map<string, string> }
       ).syncedFiles = new Map();
       (
-        freshPlugin as unknown as { loadedSuccesfully: boolean }
-      ).loadedSuccesfully = false;
+        freshPlugin as unknown as { loadedSuccessfully: boolean }
+      ).loadedSuccessfully = false;
       freshPlugin.settings = { ...plugin.settings, autoSync: false };
 
       freshPlugin.loadData = jest.fn().mockResolvedValue({
@@ -162,8 +162,9 @@ describe("Plugin lifecycle", () => {
 
     it("should save cache on unload when loaded successfully", async () => {
       // Set loadedSuccessfully to true
-      (plugin as unknown as { loadedSuccesfully: boolean }).loadedSuccesfully =
-        true;
+      (
+        plugin as unknown as { loadedSuccessfully: boolean }
+      ).loadedSuccessfully = true;
 
       // Add a file to the cache
       const syncedFiles = getPrivateProperty<Map<string, string>>(
@@ -182,8 +183,9 @@ describe("Plugin lifecycle", () => {
     });
 
     it("should clear timeouts on unload", async () => {
-      (plugin as unknown as { loadedSuccesfully: boolean }).loadedSuccesfully =
-        true;
+      (
+        plugin as unknown as { loadedSuccessfully: boolean }
+      ).loadedSuccessfully = true;
 
       // Add a timeout
       const syncTimeouts = getPrivateProperty<Map<string, NodeJS.Timeout>>(
@@ -201,8 +203,9 @@ describe("Plugin lifecycle", () => {
     });
 
     it("should not save cache if plugin did not load successfully", async () => {
-      (plugin as unknown as { loadedSuccesfully: boolean }).loadedSuccesfully =
-        false;
+      (
+        plugin as unknown as { loadedSuccessfully: boolean }
+      ).loadedSuccessfully = false;
 
       plugin.onunload();
 
@@ -393,8 +396,10 @@ describe("Plugin lifecycle", () => {
       jest.useRealTimers();
     });
 
-    it("should register modify event when autoSync is enabled", () => {
-      plugin.settings.autoSync = true;
+    it("should register the modify listener regardless of autoSync setting", () => {
+      // Registered unconditionally so toggling auto-sync takes effect without
+      // a reload; the autoSync check now lives inside the handler.
+      plugin.settings.autoSync = false;
 
       const registerEvents = getPrivateMethod<() => void>(
         plugin,
@@ -405,8 +410,20 @@ describe("Plugin lifecycle", () => {
       expect(plugin.registerEvent).toHaveBeenCalled();
     });
 
-    it("should not register modify event when autoSync is disabled", () => {
+    it("should not debounce-sync on modify when autoSync is disabled", () => {
       plugin.settings.autoSync = false;
+
+      let modifyCallback: ((file: TFile) => void) | null = null;
+      (plugin.app.vault.on as jest.Mock) = jest
+        .fn()
+        .mockImplementation(
+          (event: string, callback: (file: TFile) => void) => {
+            if (event === "modify") {
+              modifyCallback = callback;
+            }
+            return { event, callback };
+          }
+        );
 
       const registerEvents = getPrivateMethod<() => void>(
         plugin,
@@ -414,7 +431,52 @@ describe("Plugin lifecycle", () => {
       );
       registerEvents();
 
-      expect(plugin.registerEvent).not.toHaveBeenCalled();
+      const file = createMockTFile("test.md");
+      if (modifyCallback) {
+        modifyCallback(file);
+      }
+
+      const syncTimeouts = getPrivateProperty<Map<string, NodeJS.Timeout>>(
+        plugin,
+        "syncTimeouts"
+      );
+      expect(syncTimeouts.has(file.path)).toBe(false);
+    });
+
+    it("should debounce-sync on modify once autoSync is toggled on (no reload)", () => {
+      // Listener registered while autoSync was off, then enabled at runtime.
+      plugin.settings.autoSync = false;
+
+      let modifyCallback: ((file: TFile) => void) | null = null;
+      (plugin.app.vault.on as jest.Mock) = jest
+        .fn()
+        .mockImplementation(
+          (event: string, callback: (file: TFile) => void) => {
+            if (event === "modify") {
+              modifyCallback = callback;
+            }
+            return { event, callback };
+          }
+        );
+
+      const registerEvents = getPrivateMethod<() => void>(
+        plugin,
+        "registerEvents"
+      );
+      registerEvents();
+
+      plugin.settings.autoSync = true;
+
+      const file = createMockTFile("test.md");
+      if (modifyCallback) {
+        modifyCallback(file);
+      }
+
+      const syncTimeouts = getPrivateProperty<Map<string, NodeJS.Timeout>>(
+        plugin,
+        "syncTimeouts"
+      );
+      expect(syncTimeouts.has(file.path)).toBe(true);
     });
 
     it("should trigger debounced sync on markdown file modify", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "ESNext",
     "target": "ES6",
     "allowJs": true,
-    "noImplicitAny": true,
+    "strict": true,
     "moduleResolution": "node",
     "importHelpers": true,
     "declaration": true,


### PR DESCRIPTION
Second PR of the **a4r** code-quality epic (PR 1 was #54). Groups correctness bugs the test suite couldn't see (mocks modeled an idealized Obsidian/Cloudflare), plus type-safety and DRY debt. Everything is in `main.ts`.

## Runtime bugs
- **kor (P1 race):** the ribbon icon and "sync all" command fired `syncAllFiles()` and `removeOrphanedUploads()` concurrently with bare `void`. Both mutate the `syncedFiles` Map and write `cache.json` — `removeOrphanedUploads` iterated the Map while `syncAllFiles` `.set()` into it (iterator invalidation) and the two cache writes raced (last-writer-wins). Now funneled through a single `syncAllAndCleanup()` that awaits them sequentially.
- **dqh:** the vault `modify` listener was only registered when `autoSync` was true *at load time*, so toggling auto-sync did nothing until a reload. Register the listener unconditionally and gate on the live setting inside the handler.
- **1se:** the auto-sync delay field ran `parseInt(value)` with no radix or NaN guard; non-numeric input yielded `NaN` and `setTimeout(fn, NaN)` fires immediately. Validate and fall back to the default delay.

## Type safety
- **2mp:** enable tsconfig `strict`. Handle the `buildKVKey(): string | null` path explicitly — this surfaced a latent bug: a `collection` with a missing `id` produced the literal key `"collection/undefined"` instead of `null`. `catch` variables are now `unknown`; interpolations wrapped in `String()`.

## DRY
- **921:** extract a single `isPlainObject()` type guard (was duplicated 4×).
- **yu1:** share the load-validate-merge dance via `mergeWithDefaults()` across `loadSettings`/`loadCache`. (depends on 921)
- **bva:** add a `cachePath` getter and drop the vestigial `CloudflareKVCache` field — `syncedFiles` (the Map) is the source of truth, now serialized directly.
- **dzt:** extract a `BatchOutcome` accumulator + `finishBatch()` for the shared success/failure/log/notice tail of `syncAllFiles` and `removeOrphanedUploads`.
- **bg3:** remove the dead `if (loadedSuccesfully)` onload guard (onload returns on failure, so it was always true) and fix the `loadedSuccesfully` → `loadedSuccessfully` misspelling.

## Error log (0h9)
The error log did a full read-all + write-all on every write — O(n²) and unbounded, so a misconfigured auto-sync with a bad token could balloon a vault file. Now appends on the hot path and rotates (keeps the newest ~half, cut at an entry boundary) only when the file crosses a 1 MB cap. Mock gains `adapter.append`/`adapter.stat`.

## Validation
- `pnpm test`: **202 passed**, branch coverage **92.4%** (>90% gate)
- `tsc -noEmit` under `strict`: clean
- `pnpm run build`, eslint, prettier: clean

Tests were updated for the new behavior: append-based logging, unconditional event registration with handler-level gating, `null` KV keys, and the renamed field.

Epic: `obsidian-cloudflare-kv-sync-a4r`. Closes kor, dqh, 1se, 921, yu1, bva, dzt, bg3, 0h9, 2mp.

Remaining for a later session: PR 3 — r2z (docs/UI drift, gated on merging `origin/post-plugin-acceptance`) and sg7 (release.yml npm→pnpm).